### PR TITLE
Add strict i18n template literal rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ You can use the `typescript` preset to get reasonable defaults (it includes the 
 - [`dangerously-set-inner-html`](#dangerously-set-inner-html)
 - [`describe-with-filename`](#describe-with-filename)
 - [`i18n-no-interpolated-values`](#i18n-no-interpolated-values)
+- [`i18n-no-reference`](#i18n-no-reference)
 - [`i18n-no-tagged-templates`](#i18n-no-tagged-templates)
+- [`i18n-no-template-literal`](#i18n-no-template-literal)
 - [`no-sinon-assert-called-if-called-with`](#no-sinon-assert-called-if-called-with)
 - [`one-top-level-describe-per-test`](#one-top-level-describe-per-test)
 - [`only-log-strings`](#only-log-strings)
@@ -116,6 +118,20 @@ i18n.gettext(`some ${value}`)
 i18n.gettext(`some %(value)s`)
 ```
 
+### `i18n-no-reference`
+
+Ensure predictable static values are passed as i18n method arguments:
+
+```js
+// BAD
+i18n.gettext(hello)
+
+// GOOD
+i18n.gettext('hello')
+```
+
+:bulb: We enforce this rule because of the following issue: https://github.com/mozilla/eslint-plugin-amo/issues/232.
+
 ### `i18n-no-tagged-templates`
 
 Ensure no template literal tags are passed to i18n methods:
@@ -131,6 +147,22 @@ i18n.gettext('hello')
 :wrench: Use the ESLint `--fix` option on the command line to automatically fixes problems reported by this rule.
 
 :bulb: We enforce this rule because of the following issue: https://github.com/mozilla/addons-frontend/issues/2108.
+
+### `i18n-no-template-literal`
+
+Ensure predictable static values are passed as i18n method arguments:
+
+```js
+// BAD
+i18n.gettext(`
+
+hello`)
+
+// GOOD
+i18n.gettext('hello')
+```
+
+:wrench: Use the ESLint `--fix` option on the command line to automatically fixes problems reported by this rule.
 
 ### `no-sinon-assert-called-if-called-with`
 

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -15,6 +15,7 @@ const I18N_METHODS = {
   dcnpgettext: [2, 3],
   // This is used in https://github.com/mozilla/addons-linter.
   _: [0],
+  sprintf: [0],
 };
 
 module.exports = { I18N_METHODS };

--- a/lib/rules/i18n-no-reference.js
+++ b/lib/rules/i18n-no-reference.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const { I18N_METHODS } = require('../i18n.js');
+
+const isReferenceNode = (node) => {
+  if (node.type === 'TemplateLiteral') {
+    return false;
+  }
+
+  return node.type !== 'Literal' || typeof node.value !== 'string';
+};
+
+const extractI18nMethodAndArgs = (node) => {
+  let result = [];
+
+  if (node.type === 'CallExpression') {
+    const { callee } = node;
+    if (callee.type === 'MemberExpression') {
+      const { object, property } = callee;
+      if (object.name === 'i18n') {
+        result = [property.name, node.arguments];
+      }
+    }
+  }
+
+  return result;
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      githubIssue: 'https://github.com/mozilla/eslint-plugin-amo/issues/232',
+      category: 'Possible Errors',
+      description:
+        'Ensure predictable static values are passed as i18n method arguments',
+      recommended: true,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noDynamicValue:
+        'invalid argument type "{{ arg }}" passed to i18n.{{ method }}(). Only static values or calls to i18n methods are allowed.',
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.getSourceCode();
+
+    return {
+      CallExpression(node) {
+        const [methodName, methodArgs] = extractI18nMethodAndArgs(node);
+
+        if (!methodName || !methodArgs || methodName.includes('ngettext')) {
+          return;
+        }
+
+        const positions = I18N_METHODS[methodName] || [];
+
+        positions.forEach((position) => {
+          const arg = methodArgs[position];
+
+          const [argMethod] = extractI18nMethodAndArgs(arg);
+
+          if (isReferenceNode(arg) && !argMethod) {
+            context.report({
+              node,
+              messageId: 'noDynamicValue',
+              data: {
+                method: methodName,
+                arg: sourceCode.getText(arg),
+              },
+            });
+          }
+        });
+      },
+    };
+  },
+};

--- a/lib/rules/i18n-no-template-literal.js
+++ b/lib/rules/i18n-no-template-literal.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const { I18N_METHODS } = require('../i18n.js');
+
+const toStaticString = (quasis) => {
+  return quasis
+    .map((quasi) => {
+      let text = quasi.value.raw;
+      text = text.replace(/'/g, "\\'"); // Escape single quotes
+      text = text.replace(/"/g, '\\"'); // Escape double quotes
+      return text;
+    })
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      category: 'Possible Errors',
+      description:
+        'Ensure predictable static values are passed as i18n method arguments',
+      recommended: true,
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      noStaticTemplate:
+        'Do not use template literals on i18n.{{method}} for positional argument {{position}}. Use literal strings instead.',
+    },
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        const { callee, arguments: args } = node;
+
+        if (!callee.type === 'MemberExpression' || !args.length) {
+          return;
+        }
+
+        const { object, property } = node.callee;
+
+        if (object?.name !== 'i18n') {
+          return;
+        }
+
+        const positions = I18N_METHODS[property.name] || [];
+
+        positions.forEach((position) => {
+          const arg = args[position];
+
+          if (arg.type === 'TemplateLiteral') {
+            // Template literal without dynamic placeholders
+            const reportObject = {
+              node,
+              messageId: 'noStaticTemplate',
+              data: {
+                method: property.name,
+                position,
+              },
+            };
+
+            if (!arg.expressions || arg.expressions.length === 0) {
+              reportObject.fix = (fixer) => {
+                const fixedValue = toStaticString(arg.quasis);
+                return fixer.replaceText(arg, `'${fixedValue}'`);
+              };
+            }
+
+            context.report(reportObject);
+          }
+        });
+      },
+    };
+  },
+};

--- a/tests/lib/rules/i18n-no-reference.js
+++ b/tests/lib/rules/i18n-no-reference.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const rule = require('../../../lib/rules/i18n-no-reference');
+const RuleTester = require('eslint').RuleTester;
+
+const { I18N_METHODS } = require('../../../lib/i18n');
+const { getI18nValidCases, getI18nInvalidCases } = require('../../utils');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+const methods = Object.entries(I18N_METHODS).filter(
+  ([method]) => !method.includes('ngettext')
+);
+
+const invalidNoRefInputs = [
+  'foo',
+  'foo.bar',
+  'this.props.foo',
+  'foo()',
+  'window.foo',
+  'undefined',
+  'null',
+];
+
+const examples = {
+  valid: [
+    "i18n.gettext('hello')",
+    ...getI18nValidCases(methods, [
+      "'hello'",
+      '"hello"',
+      '"${hello}"',
+      "i18n.gettext('foo')",
+    ]),
+  ],
+  invalid: [
+    {
+      code: 'i18n.gettext(hello)',
+      errors: [
+        {
+          messageId: 'noDynamicValue',
+          // ensures the source code is passed to the reporter
+          data: { arg: 'hello', method: 'gettext' },
+        },
+      ],
+    },
+    ...getI18nInvalidCases(
+      methods,
+      invalidNoRefInputs.map((input) => ({
+        input,
+        errors: [{ messageId: 'noDynamicValue' }],
+      }))
+    ),
+  ],
+};
+
+ruleTester.run('i18n-no-reference', rule, examples);
+
+module.exports = { examples };

--- a/tests/lib/rules/i18n-no-template-literal.js
+++ b/tests/lib/rules/i18n-no-template-literal.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const rule = require('../../../lib/rules/i18n-no-template-literal');
+const RuleTester = require('eslint').RuleTester;
+
+const { I18N_METHODS } = require('../../../lib/i18n');
+const { getI18nValidCases, getI18nInvalidCases } = require('../../utils');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+const methods = Object.entries(I18N_METHODS);
+
+const examples = {
+  valid: [
+    "i18n.gettext('hello')",
+    ...getI18nValidCases(methods, ["'hello'", '"hello"', '"${hello}"']),
+  ],
+  invalid: [
+    {
+      code: 'i18n.gettext(`\n\nhello`)',
+      errors: [
+        {
+          messageId: 'noStaticTemplate',
+          // ensure the method and position are passed to the reporter
+          data: { method: 'gettext', position: 0 },
+        },
+      ],
+      output: "i18n.gettext('hello')",
+    },
+    ...getI18nInvalidCases(methods, [
+      {
+        input: '`hello`',
+        errors: [{ messageId: 'noStaticTemplate' }],
+        output: "'hello'",
+      },
+      {
+        input: `\`This add-on is not compatible with your
+        version of Firefox.\``,
+        errors: [{ messageId: 'noStaticTemplate' }],
+        output: "'This add-on is not compatible with your version of Firefox.'",
+      },
+      {
+        input: '`hello ${world}`',
+        errors: [{ messageId: 'noStaticTemplate' }],
+      },
+      {
+        input: '`hello\n\nworld`',
+        errors: [{ messageId: 'noStaticTemplate' }],
+        output: "'hello world'",
+      },
+      {
+        input: '`hello           `',
+        errors: [{ messageId: 'noStaticTemplate' }],
+        output: "'hello'",
+      },
+      {
+        input: "`Explore our 'Starter Pack' to get started with extensions`",
+        errors: [{ messageId: 'noStaticTemplate' }],
+        output: `'Explore our \\'Starter Pack\\' to get started with extensions'`,
+      },
+      {
+        input: '`Explore our "Starter Pack" to get started with extensions`',
+        errors: [{ messageId: 'noStaticTemplate' }],
+        output: `'Explore our \\"Starter Pack\\" to get started with extensions'`,
+      },
+    ]),
+  ],
+};
+
+ruleTester.run('i18n-template-literal', rule, examples);
+
+module.exports = { examples };

--- a/tests/test_utils.js
+++ b/tests/test_utils.js
@@ -1,0 +1,91 @@
+const assert = require('assert');
+
+const { getI18nValidCases, getI18nInvalidCases } = require('./utils');
+
+const methods = [
+  ['gettext', [0]],
+  ['dgettext', [1]],
+  ['dcgettext', [2, 3]],
+];
+
+describe('utils', () => {
+  it('creates valid tests for all i18n methods', () => {
+    const tests = getI18nValidCases(methods, ['"hello"']);
+
+    assert.deepEqual(tests, [
+      {
+        code: 'i18n.gettext("hello")',
+      },
+      {
+        code: `i18n.dgettext('static', "hello")`,
+      },
+      {
+        code: `i18n.dcgettext('static', 'static', "hello", "hello")`,
+      },
+    ]);
+  });
+
+  it('creates invalid tests for all i18n methods', () => {
+    const tests = getI18nInvalidCases(methods, [
+      {
+        input: '`hello`',
+        errors: [{ messageId: 'noDynamicValue' }],
+      },
+    ]);
+
+    assert.deepEqual(tests, [
+      {
+        code: 'i18n.gettext(`hello`)',
+        errors: [
+          {
+            messageId: 'noDynamicValue',
+          },
+        ],
+      },
+      {
+        code: "i18n.dgettext('static', `hello`)",
+        errors: [
+          {
+            messageId: 'noDynamicValue',
+          },
+        ],
+      },
+      {
+        code: "i18n.dcgettext('static', 'static', `hello`, `hello`)",
+        errors: [
+          {
+            messageId: 'noDynamicValue',
+          },
+          {
+            messageId: 'noDynamicValue',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('creates invalid tests with output', () => {
+    const tests = getI18nInvalidCases(
+      [['gettext', [0]]],
+      [
+        {
+          input: '`hello`',
+          errors: [{ messageId: 'noDynamicValue' }],
+          output: "'hello'",
+        },
+      ]
+    );
+
+    assert.deepEqual(tests, [
+      {
+        code: 'i18n.gettext(`hello`)',
+        errors: [
+          {
+            messageId: 'noDynamicValue',
+          },
+        ],
+        output: "i18n.gettext('hello')",
+      },
+    ]);
+  });
+});

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,58 @@
+const mapPositionsToArgs = (replacement, positions, staticArg) => {
+  const args = [];
+
+  const highestPosition = positions[positions.length - 1];
+
+  for (let i = 0; i <= highestPosition; i++) {
+    if (positions.includes(i)) {
+      if (Array.isArray(replacement)) {
+        args.push(...replacement);
+      } else {
+        args.push(replacement);
+      }
+    } else if (staticArg) {
+      args.push(staticArg);
+    }
+  }
+
+  return args;
+};
+
+const getArgs = (arg, positions) => {
+  const args = mapPositionsToArgs(arg, positions, "'static'");
+  return args.length > 1 ? args.join(', ') : args[0];
+};
+
+const getI18nValidCases = (methods, validInputs) => {
+  return methods.reduce((acc, [method, positions]) => {
+    const valid = validInputs.map((input) => {
+      const args = getArgs(input, positions);
+      return {
+        code: `i18n.${method}(${args})`,
+      };
+    });
+    return [...acc, ...valid];
+  }, []);
+};
+
+const getI18nInvalidCases = (methods, invalidInputs) => {
+  return methods.reduce((acc, [method, positions]) => {
+    const invalid = invalidInputs.map(({ input, errors, output }) => {
+      const args = getArgs(input, positions);
+      const config = {
+        code: `i18n.${method}(${args})`,
+        errors: mapPositionsToArgs(errors, positions),
+      };
+      if (output) {
+        config.output = `i18n.${method}(${getArgs(output, positions)})`;
+      }
+      return config;
+    });
+    return [...acc, ...invalid];
+  }, []);
+};
+
+module.exports = {
+  getI18nValidCases,
+  getI18nInvalidCases,
+};


### PR DESCRIPTION
fixes: #232

In the process of investigating https://github.com/mozilla/addons-server/issues/9112

I found that our eslint rules for i18n allow for two edge cases that we should probably forbid or fix.

## 1. non literal strings as arguments.

Passing dynamic content to i18n methods that should return translations make the inputs NOT unpredictable  and therefore extraction cannot generate valid locale entries. You can see examples of invalid reference passing in the tests of this PR but examples are 

- window.foo
- foo()
- this.props.foo

These values could be anything and therefore cannot be tracked in a locale. The reason for this rule is the same as why you would have a rule for no interpolated values.

## 2. Template literals as arguments

Similar to the first rule, this is simply a more strict version of an existing rule. We already don't allow interpolated value expressions in template literals, as well as not allowing tagged template literals.

This rule goes one step further and fixes static template literals to normal strings. There are only 2 reasons to use template literals:

- passing dyanmic expressions
- adding explicit spacing and line breaks.

We already forbid the first case and the second case is artificially removed from our code during extraction making the extraction process more complex than it needs to be. 

By solving this at the linting level we can prevent any template literals from entering the equation at all.

These rules are thoroughly tested against all methods of i18n using our existing configuration for identifying positional arguments in i18n methods we want to protect. This PR introduces 2 utility meethods that allow you to generate test cases against all methods and positions from a static array of predefined inputs, outputs, and errors.

These could be used for other or the existing i18n rule tests, you know, if you want.
