### PR TITLE
Add linting for the linting plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,15 @@ jobs:
       - *save_next_build_cache
       - run: npm test
 
+  lint:
+    <<: *defaults
+    steps:
+      - checkout
+      - *restore_build_cache
+      - *run_npm_install
+      - *save_build_cache
+      - run: npm run lint
+
   release-tag:
     <<: *defaults
     steps:
@@ -93,9 +102,11 @@ workflows:
             tags:
               only: /.*/
       - test-next
+      - lint
       - release-tag:
           requires:
             - test
+            - lint
           filters:
             tags:
               only: /.*/

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,4 +5,5 @@
 /node_modules/
 # white-list files we want to process
 !*.js
+!*.mjs
 !*.md

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,12 @@
+import globals from 'globals';
+import pluginJs from '@eslint/js';
+import eslintPlugin from 'eslint-plugin-eslint-plugin';
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [
+  { files: ['**/*.js'], languageOptions: { sourceType: 'commonjs' } },
+  { languageOptions: { globals: globals.node } },
+  pluginJs.configs.recommended,
+  eslintPlugin.configs['flat/recommended'],
+  { files: ['tests/**/*.js'], languageOptions: { globals: globals.mocha } },
+];

--- a/lib/rules/dangerously-set-inner-html.js
+++ b/lib/rules/dangerously-set-inner-html.js
@@ -8,6 +8,7 @@ module.exports = {
         'Ensure `dangerouslySetInnerHTML` is used on elements that permit flow content',
       recommended: true,
     },
+    type: 'problem',
     messages: {
       invalidElementForSanitizeUserHTML:
         'Do not use `dangerouslySetInnerHTML` on `<{{ element }}>` when using `sanitizeUserHTML()`, use a `<div>`.',

--- a/lib/rules/describe-with-filename.js
+++ b/lib/rules/describe-with-filename.js
@@ -9,6 +9,7 @@ module.exports = {
       githubIssue: 'https://github.com/mozilla/addons-frontend/issues/2928',
       recommended: true,
     },
+    type: 'suggestion',
     messages: {
       invalidDescription:
         'Use `__filename` in the description of the top-level `describe` block.',

--- a/lib/rules/i18n-no-interpolated-values.js
+++ b/lib/rules/i18n-no-interpolated-values.js
@@ -9,6 +9,7 @@ module.exports = {
       description: 'Ensure no interpolated values are passed to i18n methods',
       recommended: true,
     },
+    type: 'problem',
     messages: {
       noInterpolatedValues:
         'Do not use interpolated values (e.g. `${variable}`) when calling a `i18n` method.',

--- a/lib/rules/i18n-no-reference.js
+++ b/lib/rules/i18n-no-reference.js
@@ -34,6 +34,7 @@ module.exports = {
       description:
         'Ensure predictable static values are passed as i18n method arguments',
     },
+    type: 'problem',
     fixable: null,
     schema: [],
     messages: {

--- a/lib/rules/i18n-no-tagged-templates.js
+++ b/lib/rules/i18n-no-tagged-templates.js
@@ -10,6 +10,7 @@ module.exports = {
       githubIssue: 'https://github.com/mozilla/addons-frontend/issues/2108',
       recommended: true,
     },
+    type: 'problem',
     messages: {
       noTemplateLiteralTags:
         'Do not use a template literal tag such as "{{ tag }}" when calling a `i18n` method.',

--- a/lib/rules/i18n-no-template-literal.js
+++ b/lib/rules/i18n-no-template-literal.js
@@ -22,6 +22,7 @@ module.exports = {
       description:
         'Ensure predictable static values are passed as i18n method arguments',
     },
+    type: 'problem',
     fixable: 'code',
     schema: [],
     messages: {

--- a/lib/rules/no-sinon-assert-called-if-called-with.js
+++ b/lib/rules/no-sinon-assert-called-if-called-with.js
@@ -9,6 +9,7 @@ module.exports = {
       githubIssue: 'https://github.com/mozilla/addons-frontend/issues/2437',
       recommended: true,
     },
+    type: 'suggestion',
     messages: {
       error:
         'No need to use `sinon.assert.called()` when you use `sinon.assert.calledWith()` on the same spy.',

--- a/lib/rules/one-top-level-describe-per-test.js
+++ b/lib/rules/one-top-level-describe-per-test.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       category: 'Stylistic Issues',
       description:

--- a/lib/rules/only-log-strings.js
+++ b/lib/rules/only-log-strings.js
@@ -8,6 +8,7 @@ module.exports = {
       githubIssue: 'https://github.com/mozilla/addons-frontend/issues/6512',
       recommended: true,
     },
+    type: 'problem',
     messages: {
       error:
         'We do not recommend to log objects. Make sure it is really what you want to do.',

--- a/lib/rules/only-tsx-files.js
+++ b/lib/rules/only-tsx-files.js
@@ -10,6 +10,7 @@ module.exports = {
       recommended: true,
       typescript: true,
     },
+    type: 'problem',
     messages: {
       error: 'Only use `.tsx` file extensions in a TypeScript project.',
     },

--- a/lib/rules/redux-app-state.js
+++ b/lib/rules/redux-app-state.js
@@ -9,6 +9,7 @@ module.exports = {
       githubIssue: 'https://github.com/mozilla/addons-frontend/issues/4058',
       recommended: true,
     },
+    type: 'problem',
     messages: {
       invalidStateType: 'Use the `AppState` Flow type on the `state` argument.',
     },

--- a/lib/rules/sort-destructured-props.js
+++ b/lib/rules/sort-destructured-props.js
@@ -10,6 +10,7 @@ module.exports = {
       githubIssue: null,
       recommended: false,
     },
+    type: 'suggestion',
     messages: {
       error:
         'Destructured props must be sorted. Example: `const { Component, _a, b, c } = props;`',
@@ -39,10 +40,10 @@ module.exports = {
         const { properties } = node;
 
         const props = properties
-          .map((property, index) => {
+          .map((property) => {
             const { type, key, value } = property;
 
-            if (EXCLUDED_TYPES.includes(property.type)) {
+            if (EXCLUDED_TYPES.includes(type)) {
               return null;
             }
 

--- a/lib/rules/with-router-hoc-first.js
+++ b/lib/rules/with-router-hoc-first.js
@@ -8,6 +8,7 @@ module.exports = {
       githubIssue: null,
       recommended: true,
     },
+    type: 'problem',
     messages: {
       error: 'The `withRouter` HOC should be the first HOC in `compose()`',
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,10 @@
         "@babel/core": "^7.16.0",
         "@babel/eslint-parser": "^7.16.0",
         "@babel/plugin-syntax-flow": "^7.16.0",
-        "eslint": "^9.0.0",
+        "@eslint/js": "^9.21.0",
+        "eslint": "^9.21.0",
+        "eslint-plugin-eslint-plugin": "^6.4.0",
+        "globals": "^16.0.0",
         "inquirer": "^12.0.0",
         "markdown-table": "^3.0.0",
         "mocha": "^11.0.1",
@@ -315,6 +318,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@babel/types": {
       "version": "7.26.9",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
@@ -382,9 +395,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.11.0.tgz",
-      "integrity": "sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -395,9 +408,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
+      "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -432,9 +445,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.20.0.tgz",
-      "integrity": "sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.21.0.tgz",
+      "integrity": "sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -452,27 +465,14 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
-      "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
+      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.10.0",
+        "@eslint/core": "^0.12.0",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
-      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -530,9 +530,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
+      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1470,22 +1470,22 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.20.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.20.1.tgz",
-      "integrity": "sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.21.0.tgz",
+      "integrity": "sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.11.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.20.0",
-        "@eslint/plugin-kit": "^0.2.5",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.0",
+        "@eslint/js": "9.21.0",
+        "@eslint/plugin-kit": "^0.2.7",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -1527,6 +1527,33 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-eslint-plugin": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-6.4.0.tgz",
+      "integrity": "sha512-X94/hr7DnckX68wE6Qqeo3DsZndZSclfoewjwD249yG5z2EAOl3UGUohLIgOpmbUjcFv6AlfW3wxBnOiWkS1Iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "estraverse": "^5.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.23.0"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-plugin/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -1905,12 +1932,16 @@
       }
     },
     "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
+      "integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/he": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build-doc": "bin/build-doc",
+    "lint": "eslint .",
     "new-rule": "bin/new-rule",
     "prettier": "prettier --write '**'",
     "test": "mocha tests --recursive"
@@ -24,7 +25,10 @@
     "@babel/core": "^7.16.0",
     "@babel/eslint-parser": "^7.16.0",
     "@babel/plugin-syntax-flow": "^7.16.0",
-    "eslint": "^9.0.0",
+    "@eslint/js": "^9.21.0",
+    "eslint": "^9.21.0",
+    "eslint-plugin-eslint-plugin": "^6.4.0",
+    "globals": "^16.0.0",
     "inquirer": "^12.0.0",
     "markdown-table": "^3.0.0",
     "mocha": "^11.0.1",


### PR DESCRIPTION
Add linting for the ESLint plugin itself, to ensure that it meets quality standards. This includes leveraging [eslint-plugin-eslint-plugin](https://github.com/eslint-community/eslint-plugin-eslint-plugin), which has specific rules for linting ESLint plugins. I've fixed the violations from the recommended ruleset and added enforcement via the CircleCI workflow.